### PR TITLE
Remove gh-pages deploy script for Actions

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -46,7 +46,7 @@ The workflow (`.github/workflows/deploy.yml`) automatically deploys the app when
 ### package.json
 - **homepage**: Set to `https://leoakok.github.io/assistant-memory-tracker`
   - This ensures all asset paths work correctly on GitHub Pages
-- **deploy scripts**: Added for manual deployment if needed
+- **deploy scripts**: Not included; deployments are handled exclusively by GitHub Actions
 
 ### GitHub Actions Workflow
 - **Location**: `.github/workflows/deploy.yml`
@@ -91,22 +91,8 @@ If you need to manually trigger a deployment:
 4. Select the branch (usually `main`)
 5. Click "Run workflow"
 
----
-
-## 🛠️ Manual Deployment (Alternative Method)
-
-If you prefer to deploy manually without GitHub Actions:
-
-```bash
-# Install dependencies
-npm install
-
-# Build the production app
-npm run build
-
-# Deploy to GitHub Pages (requires gh-pages package)
-npm run deploy
-```
+Note: This repository deploys via GitHub Actions only. Branch-based
+deployments (for example, using `gh-pages`) are not configured.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": [
@@ -34,8 +32,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "gh-pages": "^6.1.1"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs and package metadata only; the main impact is that `npm run deploy` is no longer available.
> 
> **Overview**
> This PR removes the `gh-pages` manual deployment path by deleting the `predeploy`/`deploy` npm scripts and dropping the `gh-pages` dev dependency from `package.json`.
> 
> It updates `DEPLOYMENT.md` to clarify that deployments are handled exclusively via GitHub Actions and removes the alternative manual deployment instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d84b08711cf6b0b67d47ff0fe319f7a33e5c5f6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->